### PR TITLE
#260: Oppslag-cache som avgrensar til maks eitt oppslag per lokallag samtidig

### DIFF
--- a/src/main/kotlin/no/roedt/ringesentralen/samtale/start/NestePersonAaRingeFinder.kt
+++ b/src/main/kotlin/no/roedt/ringesentralen/samtale/start/NestePersonAaRingeFinder.kt
@@ -28,10 +28,10 @@ class NestePersonAaRingeFinder(
     fun hentNestePersonAaRinge(request: AutentisertNestePersonAaRingeRequest): NestePersonAaRingeResponse? {
         nyligeOppslagCache.assertAtIngenAndreSoekerIDetteLagetAkkuratNo(request.lokallag)
         return hentNestePersonAaRingeIDenneModusen(request)
-            ?.also { nyligeOppslagCache.remove(request.lokallag) }
             ?.let { personRepository.findById(it.toLong()) }
             ?.let { toResponse(it) }
             ?.also { oppslagRepository.persist(Oppslag(ringt = it.person.id.toInt(), ringerHypersysId = request.userId())) }
+            ?.also { nyligeOppslagCache.remove(request.lokallag) }
     }
 
     private fun hentNestePersonAaRingeIDenneModusen(request: AutentisertNestePersonAaRingeRequest): Int? =

--- a/src/main/kotlin/no/roedt/ringesentralen/samtale/start/NyligeOppslagCache.kt
+++ b/src/main/kotlin/no/roedt/ringesentralen/samtale/start/NyligeOppslagCache.kt
@@ -3,24 +3,22 @@ package no.roedt.ringesentralen.samtale.start
 import java.util.concurrent.ConcurrentHashMap
 import javax.enterprise.context.ApplicationScoped
 
+const val cacheTimeValidityInMillis: Long = 5000
+
 @ApplicationScoped
 class NyligeOppslagCache {
-    private var cacheTimeValidityInMillis: Long = 5000
     private val hashMap = ConcurrentHashMap<Int, TimedEntry>()
 
     fun assertAtIngenAndreSoekerIDetteLagetAkkuratNo(lokallag: Int) {
-        var i = 0
         while (hashMap.containsKey(lokallag) && hashMap[lokallag]!!.isGyldig()) {
-            Thread.sleep(100);
-            i++
+            Thread.sleep(100)
         }
-        hashMap[lokallag] = TimedEntry(cacheTimeValidityInMillis)
+        hashMap[lokallag] = TimedEntry()
     }
 
     fun remove(lokallag: Int) = hashMap.remove(lokallag)
 
-    data class TimedEntry(val maxDurationInMillis: Long) {
-        private val creationTime: Long = System.currentTimeMillis()
-        fun isGyldig() = (System.currentTimeMillis() - creationTime) <= maxDurationInMillis
+    data class TimedEntry(val creationTime: Long = System.currentTimeMillis()) {
+        fun isGyldig() = (System.currentTimeMillis() - creationTime) <= cacheTimeValidityInMillis
     }
 }

--- a/src/main/kotlin/no/roedt/ringesentralen/samtale/start/NyligeOppslagCache.kt
+++ b/src/main/kotlin/no/roedt/ringesentralen/samtale/start/NyligeOppslagCache.kt
@@ -1,0 +1,26 @@
+package no.roedt.ringesentralen.samtale.start
+
+import java.util.concurrent.ConcurrentHashMap
+import javax.enterprise.context.ApplicationScoped
+
+@ApplicationScoped
+class NyligeOppslagCache {
+    private var cacheTimeValidityInMillis: Long = 5000
+    private val hashMap = ConcurrentHashMap<Int, TimedEntry>()
+
+    fun assertAtIngenAndreSoekerIDetteLagetAkkuratNo(lokallag: Int) {
+        var i = 0
+        while (hashMap.containsKey(lokallag) && hashMap[lokallag]!!.isGyldig()) {
+            Thread.sleep(100);
+            i++
+        }
+        hashMap[lokallag] = TimedEntry(cacheTimeValidityInMillis)
+    }
+
+    fun remove(lokallag: Int) = hashMap.remove(lokallag)
+
+    data class TimedEntry(val maxDurationInMillis: Long) {
+        private val creationTime: Long = System.currentTimeMillis()
+        fun isGyldig() = (System.currentTimeMillis() - creationTime) <= maxDurationInMillis
+    }
+}

--- a/src/test/kotlin/no/roedt/ringesentralen/samtale/start/NestePersonAaRingeFinderTest.kt
+++ b/src/test/kotlin/no/roedt/ringesentralen/samtale/start/NestePersonAaRingeFinderTest.kt
@@ -31,7 +31,8 @@ internal class NestePersonAaRingeFinderTest {
         oppslagRepository = oppslagRepository,
         oppfoelgingValg21Repository = oppfoelgingValg21Repository,
         nesteMedlemAaRingeFinder = nesteMedlemAaRingeFinder,
-        lokallagRepository = lokallagRepository
+        lokallagRepository = lokallagRepository,
+        nyligeOppslagCache = NyligeOppslagCache()
     )
 
     @BeforeEach

--- a/src/test/kotlin/no/roedt/ringesentralen/samtale/start/NyligeOppslagCacheTest.kt
+++ b/src/test/kotlin/no/roedt/ringesentralen/samtale/start/NyligeOppslagCacheTest.kt
@@ -1,0 +1,18 @@
+package no.roedt.ringesentralen.samtale.start
+
+import org.junit.jupiter.api.Test
+import java.util.stream.IntStream
+import kotlin.concurrent.thread
+
+internal class NyligeOppslagCacheTest {
+
+    @Test
+    fun run() {
+        val cache = NyligeOppslagCache()
+        IntStream.range(0, 1000).forEach {
+            thread(start = true) {
+                cache.assertAtIngenAndreSoekerIDetteLagetAkkuratNo(1)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Eit alternativt løysingsforslag, som kjem i tillegg til frontends # 220.

5-sekundstimeouten er satt litt vilkårleg, men bør vera meir enn nok.